### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_session_path, only: :new
-  before_action :set_item, only: [:show,:edit,:update]
+  before_action :set_item, only: [:show,:edit,:update,:destroy]
 
   def index
     @items = Item.includes(:user).order("created_at DESC")
@@ -34,6 +34,11 @@ class ItemsController < ApplicationController
     else
       render "edit"
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to action: :index
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,8 +37,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to action: :index
+    if user_signed_in? && current_user.id == @item.user_id
+      @item.destroy
+      redirect_to action: :index
+    end
   end
 
   private
@@ -56,5 +58,6 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+  
 
 end

--- a/app/javascript/calc.js
+++ b/app/javascript/calc.js
@@ -11,6 +11,5 @@ function calc(){
     addTaxPrice.innerHTML = `${x}`
     profit.innerHTML = `${y}`
   });
-
 }
 window.addEventListener('load',calc)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: [:index ,:new ,:create,:show,:edit,:update]
+  resources :items
 
 end


### PR DESCRIPTION
#what 
商品削除機能の実装

#why
出品した商品を出品者のみが削除できるようにするため

- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/0579371e246309209b3a1ba96e474fae
